### PR TITLE
Update @forcecalendar/core from 2.1.7 to 2.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1873,6 +1874,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1896,6 +1898,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2326,9 +2329,9 @@
       }
     },
     "node_modules/@forcecalendar/core": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.7.tgz",
-      "integrity": "sha512-zRXkY72pIkxO297JsfciYwEwc371A9ZNT6q7TLAsuIGmigCaYCKIzgFPGg+IH8F2iYmsZ+L6p13JdqyHm+C9Vg==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.18.tgz",
+      "integrity": "sha512-/o1h5mhSFMN/wLyVO5wfF4hCzJcs2d2BCG0fOYG8rxvOZSBfDXQTLEIWLoCNKe2pFF0WlM6pxYVNDiqlBaWpcw==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -3909,6 +3912,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5622,6 +5626,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",


### PR DESCRIPTION
## Summary
- Bumps lockfile from `@forcecalendar/core@2.1.7` to `@forcecalendar/core@2.1.18`
- Picks up 11 patch releases with bug fixes and performance improvements from core
- Build and all 13 tests pass with the updated dependency

## Key fixes included
- Prototype pollution in StateManager
- ISO 8601 week number calculation
- Plugin cleanup on destroy
- BYSETPOS, sub-daily recurrence, EXDATE time matching
- Overlap detection performance (O(n²) → O(n log n) sweep-line)
- Search index staleness after event mutations
- ICS multi-category parsing
- Cache invalidation on event update/remove
- Timezone DST cache key precision
- Batch operation rollback support

## Test plan
- [x] `npm run build` — succeeds (ESM + UMD bundles)
- [x] `npm test` — 13/13 tests pass
- [ ] Manual smoke test: month/week/day views render correctly
- [ ] Manual smoke test: add/update/delete events works