### PR TITLE
fix: eliminate double-firing of calendar-event-add/update/remove CustomEvents

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -91,21 +91,23 @@ export class ForceCalendar extends BaseComponent {
         forwardEventAction('remove', data);
       })
     );
+    // Specific lifecycle events — do NOT call forwardEventAction here; the
+    // canonical event:add/update/remove handlers above already forward the
+    // generic CustomEvent.  These handlers emit only the specific variant so
+    // consumers that care about the distinction can subscribe to it without
+    // receiving the generic event a second time.
     this._busUnsubscribers.push(
       eventBus.on('event:added', data => {
-        forwardEventAction('add', data);
         this.emit('calendar-event-added', data);
       })
     );
     this._busUnsubscribers.push(
       eventBus.on('event:updated', data => {
-        forwardEventAction('update', data);
         this.emit('calendar-event-updated', data);
       })
     );
     this._busUnsubscribers.push(
       eventBus.on('event:deleted', data => {
-        forwardEventAction('remove', data);
         this.emit('calendar-event-deleted', data);
       })
     );


### PR DESCRIPTION
## Problem

`StateManager` emits two EventBus events per operation:

| Operation | Emits |
|-----------|-------|
| `addEvent()` | `event:add` + `event:added` |
| `updateEvent()` | `event:update` + `event:updated` |
| `deleteEvent()` | `event:remove` + `event:deleted` |

`ForceCalendar.setupEventListeners()` subscribed to **all six** and called `forwardEventAction()` inside both the canonical (`event:add`) and the specific (`event:added`) handlers. This caused the generic CustomEvent (`calendar-event-add`, `calendar-event-update`, `calendar-event-remove`) to fire **twice** for every single user operation.

Consumers listening to `calendar-event-add` would receive two identical events per add — causing duplicate inserts, double UI reactions, or incorrect event counts in any integration built on top of this library.

## Fix

The `event:added` / `event:updated` / `event:deleted` handlers now only emit their own specific CustomEvent. The generic forward is handled exclusively by the `event:add` / `event:update` / `event:remove` handlers.

**After this change, per operation:**
- `calendar-event-add` fires once (from `event:add`)
- `calendar-event-added` fires once (from `event:added`)

## Test plan
- [ ] All 13 existing tests pass
- [ ] Add an event — verify `calendar-event-add` fires exactly once
- [ ] Update an event — verify `calendar-event-update` fires exactly once
- [ ] Delete an event — verify `calendar-event-remove` fires exactly once