### PR TITLE
fix: shallow-copy viewData in enrichViewData to avoid mutating Core's object

### DIFF
--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -292,11 +292,15 @@ class StateManager {
   }
 
   enrichViewData(viewData) {
+    // Shallow-copy the top-level object so we never mutate what Core returned.
+    // Core may cache and reuse the same reference across calls; mutating it
+    // in-place would corrupt its internal state.
+    const enriched = { ...viewData };
     const selectedDateString = this.state.selectedDate?.toDateString();
 
     // Strategy 1: Multi-week structure (Month view)
-    if (viewData.weeks) {
-      viewData.weeks = viewData.weeks.map(week => ({
+    if (enriched.weeks) {
+      enriched.weeks = enriched.weeks.map(week => ({
         ...week,
         days: week.days.map(day => {
           const dayDate = new Date(day.date);
@@ -310,8 +314,8 @@ class StateManager {
     }
 
     // Strategy 2: Flat days structure (Week view or list view)
-    if (viewData.days) {
-      viewData.days = viewData.days.map(day => {
+    if (enriched.days) {
+      enriched.days = enriched.days.map(day => {
         const dayDate = new Date(day.date);
         return {
           ...day,
@@ -322,13 +326,13 @@ class StateManager {
     }
 
     // Strategy 3: Single day structure (Day view)
-    if (viewData.date && !viewData.days && !viewData.weeks) {
-      const dayDate = new Date(viewData.date);
-      viewData.isSelected = dayDate.toDateString() === selectedDateString;
-      viewData.events = viewData.events || this.getEventsForDate(dayDate);
+    if (enriched.date && !enriched.days && !enriched.weeks) {
+      const dayDate = new Date(enriched.date);
+      enriched.isSelected = dayDate.toDateString() === selectedDateString;
+      enriched.events = enriched.events || this.getEventsForDate(dayDate);
     }
 
-    return viewData;
+    return enriched;
   }
 
   // Selection management


### PR DESCRIPTION
## Problem

`StateManager.enrichViewData()` received the object returned by `calendar.getViewData()` and mutated it in-place:

```js
// Before — direct mutation of Core's returned reference
if (viewData.weeks) {
  viewData.weeks = viewData.weeks.map(...);   // mutates Core's object
}
if (viewData.days) {
  viewData.days = viewData.days.map(...);     // mutates Core's object
}
if (viewData.date && ...) {
  viewData.isSelected = ...;                  // mutates Core's object
  viewData.events = ...;                      // mutates Core's object
}
```

If `@forcecalendar/core` caches and reuses the same `viewData` reference across calls (common in optimized view engines), these mutations would corrupt Core's internal state. Subsequent calls to `getViewData()` would return already-enriched, potentially stale data — causing incorrect selection highlights, wrong event lists, and visual glitches that are hard to reproduce because they depend on call ordering.

## Fix

Shallow-copy the top-level object at the start of `enrichViewData` and perform all enrichment on the copy:

```js
const enriched = { ...viewData };  // Core's original is untouched
```

The inner `week.days.map()` and `days.map()` calls already produce new arrays and new day objects via spread, so only the top-level copy is needed to eliminate all direct mutations.

## Test plan
- [ ] All 13 existing tests pass
- [ ] Navigate between months — verify correct dates render each time
- [ ] Select a date, navigate away and back — verify selection clears correctly
- [ ] Add events, switch views — verify events appear correctly in all three views