### PR TITLE
fix: externalize @forcecalendar/core and declare it as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,18 +8,19 @@
       "name": "@forcecalendar/interface",
       "version": "1.0.30",
       "license": "MIT",
-      "dependencies": {
-        "@forcecalendar/core": "^2.1.7"
-      },
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
+        "@forcecalendar/core": "^2.1.18",
         "babel-jest": "^30.2.0",
         "eslint": "^8.57.1",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
         "prettier": "^3.8.1",
         "vite": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@forcecalendar/core": ">=2.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2441,6 +2442,7 @@
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.18.tgz",
       "integrity": "sha512-/o1h5mhSFMN/wLyVO5wfF4hCzJcs2d2BCG0fOYG8rxvOZSBfDXQTLEIWLoCNKe2pFF0WlM6pxYVNDiqlBaWpcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4675,6 +4677,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "url": "https://github.com/forceCalendar/interface/issues"
   },
   "homepage": "https://interface.forcecalendar.org",
-  "dependencies": {
-    "@forcecalendar/core": "^2.1.7"
+  "peerDependencies": {
+    "@forcecalendar/core": ">=2.0.0"
   },
   "devDependencies": {
+    "@forcecalendar/core": "^2.1.18",
     "@babel/core": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
     "babel-jest": "^30.2.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,11 +15,15 @@ export default defineConfig({
       }
     },
     rollupOptions: {
-      // Externalize dependencies that shouldn't be bundled
-      external: [],
+      // @forcecalendar/core is a peer dependency — consumers supply it.
+      // Bundling it would cause it to be loaded twice in projects that also
+      // import core directly, bloating every consumer's bundle unnecessarily.
+      external: ['@forcecalendar/core'],
       output: {
-        // Global variable name for UMD build
-        globals: {}
+        // Global variable name for UMD builds (script-tag / CDN consumers)
+        globals: {
+          '@forcecalendar/core': 'ForceCalendarCore'
+        }
       }
     },
     // Generate sourcemaps for debugging


### PR DESCRIPTION
## Problem

`@forcecalendar/core` was listed under `dependencies` and was not in `rollupOptions.external`, so Vite bundled it completely into both the ESM and UMD dist outputs.

Any consumer who also uses `@forcecalendar/core` directly was loading the **entire core package twice** — once inside this bundle and once from their own install. This means two separate Calendar instances, two separate event stores, and a significantly larger bundle for no benefit.

For a library that *wraps* another library, bundling the wrapped library is almost always wrong.

## Changes

**`vite.config.js`**
```js
// Before
external: []
globals: {}

// After
external: ['@forcecalendar/core']
globals: { '@forcecalendar/core': 'ForceCalendarCore' }
```

**`package.json`**
```json
// Before
"dependencies": { "@forcecalendar/core": "^2.1.7" }

// After
"peerDependencies": { "@forcecalendar/core": ">=2.0.0" },
"devDependencies": { "@forcecalendar/core": "^2.1.18", ... }
```

The `>=2.0.0` peer range allows consumers on any 2.x minor to install without peer warnings while keeping flexibility as core evolves.

## Verification

After the change the ESM dist contains a single line referencing core rather than thousands of lines of bundled code:
```js
import { Calendar as M, DateUtils as T } from "@forcecalendar/core";
```

All 13 tests pass. Build succeeds.

## Test plan
- [ ] All 13 existing tests pass
- [ ] `dist/force-calendar-interface.esm.js` contains `import ... from "@forcecalendar/core"` not bundled core code
- [ ] Install in a fresh project alongside `@forcecalendar/core` — no duplicate instance errors
- [ ] UMD build works with core loaded via script tag before interface UMD