### PR TITLE
chore: declare sideEffects to enable consumer bundle tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "dist",
     "src"
   ],
+  "sideEffects": [
+    "./src/index.js",
+    "./src/components/ForceCalendar.js",
+    "./src/components/EventForm.js"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Problem

Without a `sideEffects` field in `package.json`, bundlers (webpack, rollup, esbuild, Vite) must conservatively assume every module in the package has side effects. This blocks tree-shaking entirely — consumers who import only `DateUtils` still pull in the full component registration code.

## Which files have real side effects

| File | Side effect |
|------|-------------|
| `src/index.js` | Imports `ForceCalendar.js` for its registration side effect |
| `src/components/ForceCalendar.js` | `customElements.define('forcecal-main', ForceCalendar)` |
| `src/components/EventForm.js` | `customElements.define('forcecal-event-form', EventForm)` |

Everything else — utilities, renderers, EventBus, StateManager, DateUtils, DOMUtils, StyleUtils — is pure and safe to tree-shake.

## Change

```json
"sideEffects": [
  "./src/index.js",
  "./src/components/ForceCalendar.js",
  "./src/components/EventForm.js"
]
```

## Impact

Consumers who import only specific utilities (`DateUtils`, `DOMUtils`, renderers) from `src/` will now have those tree-shaken in their final bundle. The component registration code is preserved because those files are correctly declared as having side effects.

## Test plan
- [ ] All 13 existing tests pass
- [ ] Build a consumer project that imports only `DateUtils` — verify component code is excluded from the output bundle