### PR TITLE
Fix const declarations inside unbraced switch case

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -854,10 +854,11 @@ export class ForceCalendar extends BaseComponent {
     switch (view) {
       case 'month':
         return DateUtils.formatDate(date, 'month', locale);
-      case 'week':
+      case 'week': {
         const weekStart = DateUtils.startOfWeek(date);
         const weekEnd = DateUtils.endOfWeek(date);
         return DateUtils.formatDateRange(weekStart, weekEnd, locale);
+      }
       case 'day':
         return DateUtils.formatDate(date, 'long', locale);
       default:


### PR DESCRIPTION
## Summary
- Add block scope braces around the `week` case in `getTitle()` to prevent TDZ (Temporal Dead Zone) issues
- `const` declarations inside a `switch` without braces are scoped to the entire switch block, which can cause runtime errors in strict mode

## Test plan
- [ ] Verify `getTitle()` returns correct title for all view types (month, week, day)
- [ ] Run `npm test`