### PR TITLE
Fix overlapping events with column-splitting layout

### DIFF
--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -168,7 +168,10 @@ export class DayViewRenderer extends BaseViewRenderer {
                 ${isToday ? this.renderNowIndicator() : ''}
 
                 <!-- Timed events -->
-                ${timedEvents.map(evt => this.renderTimedEvent(evt, { compact: false })).join('')}
+                ${(() => {
+                  const layout = this.computeOverlapLayout(timedEvents);
+                  return timedEvents.map(evt => this.renderTimedEvent(evt, { compact: false, overlapLayout: layout })).join('');
+                })()}
             </div>
         `;
   }

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -147,7 +147,10 @@ export class WeekViewRenderer extends BaseViewRenderer {
                 ${day.isToday ? this.renderNowIndicator() : ''}
 
                 <!-- Timed events -->
-                ${day.timedEvents.map(evt => this.renderTimedEvent(evt, { compact: true })).join('')}
+                ${(() => {
+                  const layout = this.computeOverlapLayout(day.timedEvents);
+                  return day.timedEvents.map(evt => this.renderTimedEvent(evt, { compact: true, overlapLayout: layout })).join('');
+                })()}
             </div>
         `;
   }


### PR DESCRIPTION
## Summary
- Overlapping timed events were all positioned at the same left/right offset, causing later events to fully obscure earlier ones
- Added `computeOverlapLayout()` — a greedy column-packing algorithm that detects overlapping clusters and assigns each event a column index
- `renderTimedEvent()` now accepts an `overlapLayout` map and computes `left`/`width` using `calc()` for side-by-side rendering
- Both week and day view renderers now compute overlap layout before rendering timed events

## Test plan
- [ ] Add two overlapping events (e.g. 10–11 AM and 10:30–11:30 AM) — verify they render side-by-side
- [ ] Add three overlapping events — verify three columns
- [ ] Non-overlapping events should still render full-width
- [ ] Test in both week and day views