### PR TITLE
Fix scroll-to-current-time after view navigation

### DIFF
--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -24,6 +24,7 @@ export class DayViewRenderer extends BaseViewRenderer {
     }
 
     this.cleanup();
+    this._scrolled = false;
     const config = this.stateManager.getState().config;
     const html = this._renderDayView(viewData, config);
     this.container.innerHTML = html;

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -24,6 +24,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
     }
 
     this.cleanup();
+    this._scrolled = false;
     const config = this.stateManager.getState().config;
     const html = this._renderWeekView(viewData, config);
     this.container.innerHTML = html;


### PR DESCRIPTION
## Summary
- The `_scrolled` flag was set on first render and never reset, preventing the time grid from scrolling to 8 AM when navigating to a new week or day
- Reset `_scrolled = false` at the start of each `render()` so scroll position is recalculated on every navigation

## Test plan
- [ ] In week view, navigate to next week — verify grid scrolls to ~8 AM
- [ ] In day view, navigate to next day — verify grid scrolls to ~8 AM
- [ ] Switch from month to week view — verify scroll position