### PR TITLE
Remove duplicated renderer map and dead _createViewRenderer

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -20,6 +20,12 @@ import { DayViewRenderer } from '../renderers/DayViewRenderer.js';
 import './EventForm.js';
 
 export class ForceCalendar extends BaseComponent {
+  static RENDERERS = {
+    month: MonthViewRenderer,
+    week: WeekViewRenderer,
+    day: DayViewRenderer
+  };
+
   static get observedAttributes() {
     return ['view', 'date', 'locale', 'timezone', 'week-starts-on', 'height'];
   }
@@ -203,13 +209,7 @@ export class ForceCalendar extends BaseComponent {
 
     // Create new view using renderer classes
     try {
-      const renderers = {
-        month: MonthViewRenderer,
-        week: WeekViewRenderer,
-        day: DayViewRenderer
-      };
-
-      const RendererClass = renderers[this.currentView] || MonthViewRenderer;
+      const RendererClass = ForceCalendar.RENDERERS[this.currentView] || MonthViewRenderer;
       const viewRenderer = new RendererClass(container, this.stateManager);
       viewRenderer._viewType = this.currentView;
       this._currentViewInstance = viewRenderer;
@@ -746,13 +746,7 @@ export class ForceCalendar extends BaseComponent {
 
       // Create view renderer using the appropriate renderer class
       try {
-        const renderers = {
-          month: MonthViewRenderer,
-          week: WeekViewRenderer,
-          day: DayViewRenderer
-        };
-
-        const RendererClass = renderers[this.currentView] || MonthViewRenderer;
+        const RendererClass = ForceCalendar.RENDERERS[this.currentView] || MonthViewRenderer;
         const viewRenderer = new RendererClass(container, this.stateManager);
         viewRenderer._viewType = this.currentView;
         this._currentViewInstance = viewRenderer;
@@ -809,23 +803,6 @@ export class ForceCalendar extends BaseComponent {
 
     // Mark initial render as complete for targeted updates
     this._hasRendered = true;
-  }
-
-  /**
-   * Create a view renderer instance for the given view type
-   * Uses pure JavaScript renderer classes for Salesforce Locker Service compatibility
-   * @param {string} viewName - 'month', 'week', or 'day'
-   * @returns {BaseViewRenderer} Renderer instance
-   */
-  _createViewRenderer(viewName) {
-    const renderers = {
-      month: MonthViewRenderer,
-      week: WeekViewRenderer,
-      day: DayViewRenderer
-    };
-
-    const RendererClass = renderers[viewName] || MonthViewRenderer;
-    return new RendererClass(null, null); // Container and stateManager set after creation
   }
 
   handleNavigation(event) {


### PR DESCRIPTION
## Summary
- The renderer lookup map `{ month: ..., week: ..., day: ... }` was duplicated in three places: `_switchView()`, `afterRender()`, and the never-called `_createViewRenderer()`
- Consolidated to a single static `RENDERERS` property on ForceCalendar
- Removed `_createViewRenderer()` entirely — it was dead code that instantiated with `null, null`

## Test plan
- [ ] Verify month, week, day views all render correctly
- [ ] Verify view switching works
- [ ] Run `npm test`