### PR TITLE
Fix memory leaks in StateManager.destroy() and component disconnect

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -45,8 +45,8 @@ export class ForceCalendar extends BaseComponent {
 
     this.stateManager = new StateManager(config);
 
-    // Subscribe to state changes
-    this.stateManager.subscribe(this.handleStateChange.bind(this));
+    // Subscribe to state changes (store unsubscribe for cleanup)
+    this._stateUnsubscribe = this.stateManager.subscribe(this.handleStateChange.bind(this));
 
     // Listen for events
     this.setupEventListeners();
@@ -924,9 +924,24 @@ export class ForceCalendar extends BaseComponent {
     this.stateManager.today();
   }
 
+  unmount() {
+    // Called by disconnectedCallback — clean up all subscriptions
+    this.destroy();
+  }
+
   destroy() {
     this._busUnsubscribers.forEach(unsub => unsub());
     this._busUnsubscribers = [];
+
+    if (this._stateUnsubscribe) {
+      this._stateUnsubscribe();
+      this._stateUnsubscribe = null;
+    }
+
+    if (this._currentViewInstance && this._currentViewInstance.cleanup) {
+      this._currentViewInstance.cleanup();
+      this._currentViewInstance = null;
+    }
 
     if (this.stateManager) {
       this.stateManager.destroy();

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -432,6 +432,10 @@ class StateManager {
       this._subscriberIds.clear();
       this._subscriberIds = null;
     }
+    if (this.eventBus) {
+      this.eventBus.clear();
+      this.eventBus = null;
+    }
     this.state = null;
     this.calendar = null;
   }


### PR DESCRIPTION
## Summary
Three leak vectors fixed:

1. **StateManager.destroy()** now clears its per-instance EventBus, preventing orphaned handlers from keeping references alive
2. **ForceCalendar** now stores the unsubscribe function returned by \`stateManager.subscribe()\` and calls it during \`destroy()\`
3. **ForceCalendar.unmount()** (called by \`disconnectedCallback\`) now delegates to \`destroy()\`, ensuring all subscriptions, event bus handlers, and view renderer instances are cleaned up when the component is removed from the DOM

## Test plan
- [ ] Mount and unmount calendar — verify no lingering references in DevTools memory snapshot
- [ ] Verify calendar still works normally after mount
- [ ] Run \`npm test\`