### PR TITLE
Use getState() instead of direct state access in getTitle()

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -849,7 +849,7 @@ export class ForceCalendar extends BaseComponent {
   }
 
   getTitle(date, view) {
-    const locale = this.stateManager.state.config.locale;
+    const locale = this.stateManager.getState().config.locale;
 
     switch (view) {
       case 'month':


### PR DESCRIPTION
## Summary
- \`ForceCalendar.getTitle()\` accessed \`this.stateManager.state.config.locale\` directly, bypassing the \`getState()\` encapsulation layer
- After \`destroy()\` sets \`state = null\`, this would throw a TypeError
- Changed to use \`getState()\` for consistency and safety

## Test plan
- [ ] Verify calendar title displays correct locale-formatted text
- [ ] Run \`npm test\`