### PR TITLE
Replace hardcoded colors with CSS variables in renderers

### DIFF
--- a/src/renderers/BaseViewRenderer.js
+++ b/src/renderers/BaseViewRenderer.js
@@ -158,7 +158,7 @@ export class BaseViewRenderer {
   renderNowIndicator() {
     const now = new Date();
     const minutes = now.getHours() * 60 + now.getMinutes();
-    return `<div class="fc-now-indicator" style="position: absolute; left: 0; right: 0; top: ${minutes}px; height: 2px; background: #dc2626; z-index: 15; pointer-events: none;"></div>`;
+    return `<div class="fc-now-indicator" style="position: absolute; left: 0; right: 0; top: ${minutes}px; height: 2px; background: var(--fc-danger-color); z-index: 15; pointer-events: none;"></div>`;
   }
 
   /**

--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -19,7 +19,7 @@ export class DayViewRenderer extends BaseViewRenderer {
     const viewData = this.stateManager.getViewData();
     if (!viewData) {
       this.container.innerHTML =
-        '<div style="padding: 20px; text-align: center; color: #666;">No data available for day view.</div>';
+        '<div style="padding: 20px; text-align: center; color: var(--fc-text-secondary);">No data available for day view.</div>';
       return;
     }
 
@@ -36,14 +36,14 @@ export class DayViewRenderer extends BaseViewRenderer {
     const dayData = this._extractDayData(viewData, currentDate);
 
     if (!dayData) {
-      return '<div style="padding: 20px; text-align: center; color: #666;">No data available for day view.</div>';
+      return '<div style="padding: 20px; text-align: center; color: var(--fc-text-secondary);">No data available for day view.</div>';
     }
 
     const { dayDate, dayName, isToday, allDayEvents, timedEvents } = dayData;
     const hours = Array.from({ length: 24 }, (_, i) => i);
 
     return `
-            <div class="fc-day-view" style="display: flex; flex-direction: column; height: 100%; background: #fff; overflow: hidden;">
+            <div class="fc-day-view" style="display: flex; flex-direction: column; height: 100%; background: var(--fc-background); overflow: hidden;">
                 ${this._renderHeader(dayDate, dayName, isToday)}
                 ${this._renderAllDayRow(allDayEvents, dayDate)}
                 ${this._renderTimeGrid(timedEvents, isToday, dayDate, hours)}
@@ -95,13 +95,13 @@ export class DayViewRenderer extends BaseViewRenderer {
 
   _renderHeader(dayDate, dayName, isToday) {
     return `
-            <div class="fc-day-header" style="display: grid; grid-template-columns: 60px 1fr; border-bottom: 1px solid #e5e7eb; background: #f9fafb; flex-shrink: 0;">
-                <div style="border-right: 1px solid #e5e7eb;"></div>
+            <div class="fc-day-header" style="display: grid; grid-template-columns: 60px 1fr; border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt); flex-shrink: 0;">
+                <div style="border-right: 1px solid var(--fc-border-color);"></div>
                 <div style="padding: 16px 24px;">
-                    <div style="font-size: 12px; font-weight: 700; color: #6b7280; text-transform: uppercase; letter-spacing: 0.1em;">
+                    <div style="font-size: 12px; font-weight: 700; color: var(--fc-text-light); text-transform: uppercase; letter-spacing: 0.1em;">
                         ${dayName}
                     </div>
-                    <div style="font-size: 24px; font-weight: 600; margin-top: 4px; ${isToday ? 'color: #dc2626;' : 'color: #111827;'}">
+                    <div style="font-size: 24px; font-weight: 600; margin-top: 4px; ${isToday ? 'color: var(--fc-danger-color);' : 'color: var(--fc-text-color);'}">
                         ${dayDate.getDate()}
                     </div>
                 </div>
@@ -111,8 +111,8 @@ export class DayViewRenderer extends BaseViewRenderer {
 
   _renderAllDayRow(allDayEvents, dayDate) {
     return `
-            <div class="fc-all-day-row" style="display: grid; grid-template-columns: 60px 1fr; border-bottom: 1px solid #e5e7eb; background: #fafafa; min-height: 36px; flex-shrink: 0;">
-                <div style="font-size: 9px; color: #6b7280; display: flex; align-items: center; justify-content: center; border-right: 1px solid #e5e7eb; text-transform: uppercase; font-weight: 700;">
+            <div class="fc-all-day-row" style="display: grid; grid-template-columns: 60px 1fr; border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt); min-height: 36px; flex-shrink: 0;">
+                <div style="font-size: 9px; color: var(--fc-text-light); display: flex; align-items: center; justify-content: center; border-right: 1px solid var(--fc-border-color); text-transform: uppercase; font-weight: 700;">
                     All day
                 </div>
                 <div class="fc-all-day-cell" data-date="${dayDate.toISOString()}" style="padding: 6px 12px; display: flex; flex-wrap: wrap; gap: 4px;">
@@ -144,11 +144,11 @@ export class DayViewRenderer extends BaseViewRenderer {
 
   _renderTimeGutter(hours) {
     return `
-            <div class="fc-time-gutter" style="border-right: 1px solid #e5e7eb; background: #fafafa;">
+            <div class="fc-time-gutter" style="border-right: 1px solid var(--fc-border-color); background: var(--fc-background-alt);">
                 ${hours
                   .map(
                     h => `
-                    <div style="height: ${this.hourHeight}px; font-size: 11px; color: #6b7280; text-align: right; padding-right: 12px; font-weight: 500;">
+                    <div style="height: ${this.hourHeight}px; font-size: 11px; color: var(--fc-text-light); text-align: right; padding-right: 12px; font-weight: 500;">
                         ${h === 0 ? '' : this.formatHour(h)}
                     </div>
                 `
@@ -162,7 +162,7 @@ export class DayViewRenderer extends BaseViewRenderer {
     return `
             <div class="fc-day-column" data-date="${dayDate.toISOString()}" style="position: relative; cursor: pointer;">
                 <!-- Hour grid lines -->
-                ${hours.map(() => `<div style="height: ${this.hourHeight}px; border-bottom: 1px solid #f3f4f6;"></div>`).join('')}
+                ${hours.map(() => `<div style="height: ${this.hourHeight}px; border-bottom: 1px solid var(--fc-background-hover);"></div>`).join('')}
 
                 <!-- Now indicator for today -->
                 ${isToday ? this.renderNowIndicator() : ''}

--- a/src/renderers/MonthViewRenderer.js
+++ b/src/renderers/MonthViewRenderer.js
@@ -18,7 +18,7 @@ export class MonthViewRenderer extends BaseViewRenderer {
     const viewData = this.stateManager.getViewData();
     if (!viewData || !viewData.weeks) {
       this.container.innerHTML =
-        '<div style="padding: 20px; text-align: center; color: #666;">No data available for month view.</div>';
+        '<div style="padding: 20px; text-align: center; color: var(--fc-text-secondary);">No data available for month view.</div>';
       return;
     }
 
@@ -34,9 +34,9 @@ export class MonthViewRenderer extends BaseViewRenderer {
     const dayNames = this._getDayNames(weekStartsOn);
 
     let html = `
-            <div class="fc-month-view" style="display: flex; flex-direction: column; height: 100%; min-height: 400px; background: #fff; border: 1px solid #e5e7eb;">
-                <div class="fc-month-header" style="display: grid; grid-template-columns: repeat(7, 1fr); border-bottom: 1px solid #e5e7eb; background: #f9fafb;">
-                    ${dayNames.map(d => `<div class="fc-month-header-cell" style="padding: 12px 8px; text-align: center; font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase;">${d}</div>`).join('')}
+            <div class="fc-month-view" style="display: flex; flex-direction: column; height: 100%; min-height: 400px; background: var(--fc-background); border: 1px solid var(--fc-border-color);">
+                <div class="fc-month-header" style="display: grid; grid-template-columns: repeat(7, 1fr); border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt);">
+                    ${dayNames.map(d => `<div class="fc-month-header-cell" style="padding: 12px 8px; text-align: center; font-size: 11px; font-weight: 600; color: var(--fc-text-light); text-transform: uppercase;">${d}</div>`).join('')}
                 </div>
                 <div class="fc-month-body" style="display: flex; flex-direction: column; flex: 1;">
         `;
@@ -75,10 +75,10 @@ export class MonthViewRenderer extends BaseViewRenderer {
     const isOtherMonth = !day.isCurrentMonth;
     const isToday = day.isToday;
 
-    const dayBg = isOtherMonth ? '#f3f4f6' : '#fff';
-    const dayNumColor = isOtherMonth ? '#9ca3af' : '#111827';
+    const dayBg = isOtherMonth ? 'var(--fc-background-hover)' : 'var(--fc-background)';
+    const dayNumColor = isOtherMonth ? 'var(--fc-text-light)' : 'var(--fc-text-color)';
     const todayStyle = isToday
-      ? 'background: #2563eb; color: white; border-radius: 50%; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center;'
+      ? 'background: var(--fc-primary-color); color: white; border-radius: 50%; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center;'
       : '';
 
     const events = day.events || [];
@@ -87,13 +87,13 @@ export class MonthViewRenderer extends BaseViewRenderer {
 
     return `
             <div class="fc-month-day" data-date="${day.date}"
-                 style="background: ${dayBg}; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb; padding: 4px; min-height: 80px; cursor: pointer; display: flex; flex-direction: column;">
+                 style="background: ${dayBg}; border-right: 1px solid var(--fc-border-color); border-bottom: 1px solid var(--fc-border-color); padding: 4px; min-height: 80px; cursor: pointer; display: flex; flex-direction: column;">
                 <div class="fc-day-number" style="font-size: 13px; font-weight: 500; color: ${dayNumColor}; padding: 2px 4px; margin-bottom: 4px; ${todayStyle}">
                     ${day.dayOfMonth}
                 </div>
                 <div class="fc-day-events" style="display: flex; flex-direction: column; gap: 2px; flex: 1; overflow: hidden;">
                     ${visibleEvents.map(evt => this._renderEvent(evt)).join('')}
-                    ${moreCount > 0 ? `<div class="fc-more-events" style="font-size: 10px; color: #6b7280; padding: 2px 4px; font-weight: 500;">+${moreCount} more</div>` : ''}
+                    ${moreCount > 0 ? `<div class="fc-more-events" style="font-size: 10px; color: var(--fc-text-light); padding: 2px 4px; font-weight: 500;">+${moreCount} more</div>` : ''}
                 </div>
             </div>
         `;

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -19,7 +19,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
     const viewData = this.stateManager.getViewData();
     if (!viewData || !viewData.days || viewData.days.length === 0) {
       this.container.innerHTML =
-        '<div style="padding: 20px; text-align: center; color: #666;">No data available for week view.</div>';
+        '<div style="padding: 20px; text-align: center; color: var(--fc-text-secondary);">No data available for week view.</div>';
       return;
     }
 
@@ -52,7 +52,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
     });
 
     return `
-            <div class="fc-week-view" style="display: flex; flex-direction: column; height: 100%; background: #fff; overflow: hidden;">
+            <div class="fc-week-view" style="display: flex; flex-direction: column; height: 100%; background: var(--fc-background); overflow: hidden;">
                 ${this._renderHeader(processedDays)}
                 ${this._renderAllDayRow(processedDays)}
                 ${this._renderTimeGrid(processedDays, hours)}
@@ -62,16 +62,16 @@ export class WeekViewRenderer extends BaseViewRenderer {
 
   _renderHeader(days) {
     return `
-            <div class="fc-week-header" style="display: grid; grid-template-columns: 60px repeat(7, 1fr); border-bottom: 1px solid #e5e7eb; background: #f9fafb; flex-shrink: 0;">
-                <div style="border-right: 1px solid #e5e7eb;"></div>
+            <div class="fc-week-header" style="display: grid; grid-template-columns: 60px repeat(7, 1fr); border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt); flex-shrink: 0;">
+                <div style="border-right: 1px solid var(--fc-border-color);"></div>
                 ${days
                   .map(
                     day => `
-                    <div style="padding: 12px 8px; text-align: center; border-right: 1px solid #e5e7eb;">
-                        <div style="font-size: 10px; font-weight: 700; color: #6b7280; text-transform: uppercase; letter-spacing: 0.1em;">
+                    <div style="padding: 12px 8px; text-align: center; border-right: 1px solid var(--fc-border-color);">
+                        <div style="font-size: 10px; font-weight: 700; color: var(--fc-text-light); text-transform: uppercase; letter-spacing: 0.1em;">
                             ${day.dayName}
                         </div>
-                        <div style="font-size: 16px; font-weight: 500; margin-top: 4px; ${day.isToday ? 'background: #dc2626; color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;' : 'color: #111827;'}">
+                        <div style="font-size: 16px; font-weight: 500; margin-top: 4px; ${day.isToday ? 'background: var(--fc-danger-color); color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;' : 'color: var(--fc-text-color);'}">
                             ${day.dayOfMonth}
                         </div>
                     </div>
@@ -84,14 +84,14 @@ export class WeekViewRenderer extends BaseViewRenderer {
 
   _renderAllDayRow(days) {
     return `
-            <div class="fc-all-day-row" style="display: grid; grid-template-columns: 60px repeat(7, 1fr); border-bottom: 1px solid #e5e7eb; background: #fafafa; min-height: 32px; flex-shrink: 0;">
-                <div style="font-size: 9px; color: #6b7280; display: flex; align-items: center; justify-content: center; border-right: 1px solid #e5e7eb; text-transform: uppercase; font-weight: 700;">
+            <div class="fc-all-day-row" style="display: grid; grid-template-columns: 60px repeat(7, 1fr); border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt); min-height: 32px; flex-shrink: 0;">
+                <div style="font-size: 9px; color: var(--fc-text-light); display: flex; align-items: center; justify-content: center; border-right: 1px solid var(--fc-border-color); text-transform: uppercase; font-weight: 700;">
                     All day
                 </div>
                 ${days
                   .map(
                     day => `
-                    <div class="fc-all-day-cell" data-date="${day.date.toISOString()}" style="border-right: 1px solid #e5e7eb; padding: 4px; display: flex; flex-direction: column; gap: 2px;">
+                    <div class="fc-all-day-cell" data-date="${day.date.toISOString()}" style="border-right: 1px solid var(--fc-border-color); padding: 4px; display: flex; flex-direction: column; gap: 2px;">
                         ${day.allDayEvents
                           .map(
                             evt => `
@@ -123,11 +123,11 @@ export class WeekViewRenderer extends BaseViewRenderer {
 
   _renderTimeGutter(hours) {
     return `
-            <div class="fc-time-gutter" style="border-right: 1px solid #e5e7eb; background: #fafafa;">
+            <div class="fc-time-gutter" style="border-right: 1px solid var(--fc-border-color); background: var(--fc-background-alt);">
                 ${hours
                   .map(
                     h => `
-                    <div style="height: ${this.hourHeight}px; font-size: 10px; color: #6b7280; text-align: right; padding-right: 8px; font-weight: 500;">
+                    <div style="height: ${this.hourHeight}px; font-size: 10px; color: var(--fc-text-light); text-align: right; padding-right: 8px; font-weight: 500;">
                         ${h === 0 ? '' : this.formatHour(h)}
                     </div>
                 `
@@ -139,9 +139,9 @@ export class WeekViewRenderer extends BaseViewRenderer {
 
   _renderDayColumn(day, hours) {
     return `
-            <div class="fc-week-day-column" data-date="${day.date.toISOString()}" style="border-right: 1px solid #e5e7eb; position: relative; cursor: pointer;">
+            <div class="fc-week-day-column" data-date="${day.date.toISOString()}" style="border-right: 1px solid var(--fc-border-color); position: relative; cursor: pointer;">
                 <!-- Hour grid lines -->
-                ${hours.map(() => `<div style="height: ${this.hourHeight}px; border-bottom: 1px solid #f3f4f6;"></div>`).join('')}
+                ${hours.map(() => `<div style="height: ${this.hourHeight}px; border-bottom: 1px solid var(--fc-background-hover);"></div>`).join('')}
 
                 <!-- Now indicator for today -->
                 ${day.isToday ? this.renderNowIndicator() : ''}


### PR DESCRIPTION
## Summary
- All three view renderers used hardcoded hex values as inline styles, completely bypassing the CSS variable theming system
- Replaced ~36 hardcoded color references with their corresponding \`--fc-*\` CSS variable references
- Enables theming, dark mode support, and consistent visual customization

### Color mapping applied
| Hardcoded | CSS Variable |
|---|---|
| \`#fff\` | \`var(--fc-background)\` |
| \`#f9fafb\`, \`#fafafa\` | \`var(--fc-background-alt)\` |
| \`#f3f4f6\` | \`var(--fc-background-hover)\` |
| \`#e5e7eb\` | \`var(--fc-border-color)\` |
| \`#6b7280\` | \`var(--fc-text-light)\` |
| \`#9ca3af\` | \`var(--fc-text-light)\` |
| \`#111827\` | \`var(--fc-text-color)\` |
| \`#2563eb\` | \`var(--fc-primary-color)\` |
| \`#dc2626\` | \`var(--fc-danger-color)\` |

## Test plan
- [ ] Verify all three views render visually the same as before
- [ ] Set custom CSS variables on host — verify theming works
- [ ] Run \`npm test\`