### PR TITLE
Use contrast-aware text color for timed events

### DIFF
--- a/src/renderers/BaseViewRenderer.js
+++ b/src/renderers/BaseViewRenderer.js
@@ -174,6 +174,7 @@ export class BaseViewRenderer {
     const startMinutes = start.getHours() * 60 + start.getMinutes();
     const durationMinutes = Math.max((end - start) / (1000 * 60), compact ? 20 : 30);
     const color = this.getEventColor(event);
+    const textColor = this.getContrastingTextColor(color);
 
     const padding = compact ? '4px 8px' : '8px 12px';
     const fontSize = compact ? '11px' : '13px';
@@ -187,7 +188,7 @@ export class BaseViewRenderer {
                         left: ${margin}; right: ${rightMargin};
                         background-color: ${color}; border-radius: ${borderRadius};
                         padding: ${padding}; font-size: ${fontSize};
-                        font-weight: 500; color: white; overflow: hidden;
+                        font-weight: 500; color: ${textColor}; overflow: hidden;
                         box-shadow: 0 1px 2px rgba(0,0,0,0.1);
                         cursor: pointer; z-index: 5;">
                 <div style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">


### PR DESCRIPTION
## Summary
- Replaced hardcoded `color: white` in `renderTimedEvent()` with dynamic contrast-aware text color via `getContrastingTextColor()`
- Events with light background colors now correctly render dark text for WCAG-compliant readability

## Test plan
- [ ] Verify events with light backgrounds (e.g., `#FFE082`, `#FFFFFF`) render dark text
- [ ] Verify events with dark backgrounds (e.g., `#1565C0`, `#000000`) still render white text
- [ ] Confirm no visual regression in week and day views