### PR TITLE
Remove dead _cachedStyles property declaration

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -34,7 +34,6 @@ export class ForceCalendar extends BaseComponent {
     this.stateManager = null;
     this.currentView = null;
     this._hasRendered = false; // Track if initial render is complete
-    this._cachedStyles = null; // Cache styles to avoid recreation
     this._busUnsubscribers = [];
   }
 


### PR DESCRIPTION
## Summary
- Removed `_cachedStyles` property from the `ForceCalendar` constructor
- This property was declared and initialized to `null` but never read or written anywhere in the codebase
- Eliminates dead code that could mislead future developers into thinking a caching mechanism exists

## Test plan
- [ ] Verify calendar renders correctly in all views (month, week, day)
- [ ] Confirm no runtime errors in constructor initialization