### PR TITLE
Use locale-aware day names via Intl.DateTimeFormat

### DIFF
--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -5,6 +5,7 @@
  */
 
 import { BaseViewRenderer } from './BaseViewRenderer.js';
+import { DateUtils } from '../utils/DateUtils.js';
 
 export class DayViewRenderer extends BaseViewRenderer {
   constructor(container, stateManager) {
@@ -54,12 +55,12 @@ export class DayViewRenderer extends BaseViewRenderer {
 
   _extractDayData(viewData, currentDate) {
     let dayDate, dayName, isToday, allDayEvents, timedEvents;
-    const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const locale = this.stateManager.getState().config.locale || 'en-US';
 
     if (viewData.type === 'day' && viewData.date) {
       // Core day view structure
       dayDate = new Date(viewData.date);
-      dayName = viewData.dayName || dayNames[dayDate.getDay()];
+      dayName = viewData.dayName || DateUtils.getDayName(dayDate.getDay(), locale);
       isToday = viewData.isToday !== undefined ? viewData.isToday : this.isToday(dayDate);
       allDayEvents = viewData.allDayEvents || [];
 
@@ -82,7 +83,7 @@ export class DayViewRenderer extends BaseViewRenderer {
       const dayDataItem =
         viewData.days.find(d => this.isSameDay(new Date(d.date), currentDate)) || viewData.days[0];
       dayDate = new Date(dayDataItem.date);
-      dayName = dayNames[dayDate.getDay()];
+      dayName = DateUtils.getDayName(dayDate.getDay(), locale);
       isToday = this.isToday(dayDate);
       const events = dayDataItem.events || [];
       allDayEvents = events.filter(e => e.allDay);

--- a/src/renderers/MonthViewRenderer.js
+++ b/src/renderers/MonthViewRenderer.js
@@ -5,6 +5,7 @@
  */
 
 import { BaseViewRenderer } from './BaseViewRenderer.js';
+import { DateUtils } from '../utils/DateUtils.js';
 
 export class MonthViewRenderer extends BaseViewRenderer {
   constructor(container, stateManager) {
@@ -50,11 +51,11 @@ export class MonthViewRenderer extends BaseViewRenderer {
   }
 
   _getDayNames(weekStartsOn) {
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const locale = this.stateManager.getState().config.locale || 'en-US';
     const dayNames = [];
     for (let i = 0; i < 7; i++) {
       const dayIndex = (weekStartsOn + i) % 7;
-      dayNames.push(days[dayIndex]);
+      dayNames.push(DateUtils.getDayAbbreviation(dayIndex, locale));
     }
     return dayNames;
   }

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -5,6 +5,7 @@
  */
 
 import { BaseViewRenderer } from './BaseViewRenderer.js';
+import { DateUtils } from '../utils/DateUtils.js';
 
 export class WeekViewRenderer extends BaseViewRenderer {
   constructor(container, stateManager) {
@@ -34,7 +35,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
 
   _renderWeekView(viewData, _config) {
     const days = viewData.days;
-    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const locale = this.stateManager.getState().config.locale || 'en-US';
     const hours = Array.from({ length: 24 }, (_, i) => i);
 
     // Process days to categorize events
@@ -44,7 +45,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
       return {
         ...day,
         date: dayDate,
-        dayName: dayNames[dayDate.getDay()],
+        dayName: DateUtils.getDayAbbreviation(dayDate.getDay(), locale),
         dayOfMonth: dayDate.getDate(),
         isToday: this.isToday(dayDate),
         timedEvents: events.filter(e => !e.allDay),

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -148,6 +148,14 @@ export class DateUtils extends CoreDateUtils {
   }
 
   /**
+   * Get full day name
+   */
+  static getDayName(dayIndex, locale = 'en-US') {
+    const date = new Date(2024, 0, 7 + dayIndex); // Jan 7, 2024 is a Sunday
+    return new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(date);
+  }
+
+  /**
    * Get month name
    */
   static getMonthName(monthIndex, format = 'long', locale = 'en-US') {


### PR DESCRIPTION
## Summary
- Replaced hardcoded English day name arrays (`['Sun', 'Mon', ...]`) in MonthViewRenderer, WeekViewRenderer, and DayViewRenderer
- Now uses `DateUtils.getDayAbbreviation(dayIndex, locale)` for short names and a new `DateUtils.getDayName(dayIndex, locale)` for full names
- Both methods delegate to `Intl.DateTimeFormat`, respecting the `locale` config attribute (e.g., `fr-FR` → "lun.", "mar.", etc.)

## Test plan
- [ ] Set `locale="fr-FR"` and verify French day names render in month/week headers
- [ ] Set `locale="ja-JP"` and verify Japanese day names render correctly
- [ ] Verify default `en-US` still shows "Sun", "Mon", etc.
- [ ] Verify day view header shows full locale-aware day name (e.g., "Monday" in en-US, "lundi" in fr-FR)