### PR TITLE
Make now indicator live-updating with 60-second interval

### DIFF
--- a/src/renderers/BaseViewRenderer.js
+++ b/src/renderers/BaseViewRenderer.js
@@ -18,6 +18,7 @@ export class BaseViewRenderer {
     this.stateManager = stateManager;
     this._listeners = [];
     this._scrolled = false;
+    this._nowIndicatorTimer = null;
   }
 
   /**
@@ -36,6 +37,10 @@ export class BaseViewRenderer {
       element.removeEventListener(event, handler);
     });
     this._listeners = [];
+    if (this._nowIndicatorTimer) {
+      clearInterval(this._nowIndicatorTimer);
+      this._nowIndicatorTimer = null;
+    }
   }
 
   /**
@@ -135,6 +140,23 @@ export class BaseViewRenderer {
     const now = new Date();
     const minutes = now.getHours() * 60 + now.getMinutes();
     return `<div class="fc-now-indicator" style="position: absolute; left: 0; right: 0; top: ${minutes}px; height: 2px; background: var(--fc-danger-color); z-index: 15; pointer-events: none;"></div>`;
+  }
+
+  /**
+   * Start a timer that updates the now indicator position every 60 seconds.
+   * Call this after render() in day/week views that show a now indicator.
+   */
+  startNowIndicatorTimer() {
+    if (this._nowIndicatorTimer) {
+      clearInterval(this._nowIndicatorTimer);
+    }
+    this._nowIndicatorTimer = setInterval(() => {
+      const indicator = this.container.querySelector('.fc-now-indicator');
+      if (indicator) {
+        const now = new Date();
+        indicator.style.top = `${now.getHours() * 60 + now.getMinutes()}px`;
+      }
+    }, 60000);
   }
 
   /**

--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -30,6 +30,7 @@ export class DayViewRenderer extends BaseViewRenderer {
     this.container.innerHTML = html;
     this._attachEventHandlers();
     this._scrollToCurrentTime();
+    this.startNowIndicatorTimer();
   }
 
   _renderDayView(viewData, _config) {

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -30,6 +30,7 @@ export class WeekViewRenderer extends BaseViewRenderer {
     this.container.innerHTML = html;
     this._attachEventHandlers();
     this._scrollToCurrentTime();
+    this.startNowIndicatorTimer();
   }
 
   _renderWeekView(viewData, _config) {


### PR DESCRIPTION
## Summary
- Added `startNowIndicatorTimer()` to `BaseViewRenderer` that updates the red "now" line position every 60 seconds
- Timer is automatically cleared in `cleanup()` to prevent memory leaks on view switches or component destruction
- Both `WeekViewRenderer` and `DayViewRenderer` now call `startNowIndicatorTimer()` after render

## Test plan
- [ ] Open day or week view and observe the red now-indicator line
- [ ] Wait 60+ seconds and verify the line moves to reflect the current time
- [ ] Switch views (month → week → day) and verify no leaked timers (check with DevTools Performance tab)
- [ ] Verify indicator is cleaned up when navigating away from time-based views