### PR TITLE
Fix Prettier formatting in renderer files

### DIFF
--- a/src/renderers/BaseViewRenderer.js
+++ b/src/renderers/BaseViewRenderer.js
@@ -157,7 +157,9 @@ export class BaseViewRenderer {
     });
 
     // Sort by start time, then by longer duration first
-    entries.sort((a, b) => a.startMin - b.startMin || (b.endMin - b.startMin) - (a.endMin - a.startMin));
+    entries.sort(
+      (a, b) => a.startMin - b.startMin || b.endMin - b.startMin - (a.endMin - a.startMin)
+    );
 
     // Assign columns greedily
     const columns = []; // each column tracks the end time of its last event

--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -172,7 +172,11 @@ export class DayViewRenderer extends BaseViewRenderer {
                 <!-- Timed events -->
                 ${(() => {
                   const layout = this.computeOverlapLayout(timedEvents);
-                  return timedEvents.map(evt => this.renderTimedEvent(evt, { compact: false, overlapLayout: layout })).join('');
+                  return timedEvents
+                    .map(evt =>
+                      this.renderTimedEvent(evt, { compact: false, overlapLayout: layout })
+                    )
+                    .join('');
                 })()}
             </div>
         `;
@@ -187,7 +191,11 @@ export class DayViewRenderer extends BaseViewRenderer {
       const date = new Date(dayEl.dataset.date);
       const scrollContainer = this.container.querySelector('#day-scroll-container');
       const gridTop = dayEl.offsetTop;
-      const y = e.clientY - dayEl.getBoundingClientRect().top + (scrollContainer ? scrollContainer.scrollTop : 0) - gridTop;
+      const y =
+        e.clientY -
+        dayEl.getBoundingClientRect().top +
+        (scrollContainer ? scrollContainer.scrollTop : 0) -
+        gridTop;
 
       // Calculate time from click position within the 1440px time grid
       const clampedY = Math.max(0, Math.min(y + gridTop, this.totalHeight));

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -151,7 +151,11 @@ export class WeekViewRenderer extends BaseViewRenderer {
                 <!-- Timed events -->
                 ${(() => {
                   const layout = this.computeOverlapLayout(day.timedEvents);
-                  return day.timedEvents.map(evt => this.renderTimedEvent(evt, { compact: true, overlapLayout: layout })).join('');
+                  return day.timedEvents
+                    .map(evt =>
+                      this.renderTimedEvent(evt, { compact: true, overlapLayout: layout })
+                    )
+                    .join('');
                 })()}
             </div>
         `;
@@ -166,7 +170,11 @@ export class WeekViewRenderer extends BaseViewRenderer {
       const date = new Date(dayEl.dataset.date);
       const scrollContainer = this.container.querySelector('#week-scroll-container');
       const gridTop = dayEl.offsetTop;
-      const y = e.clientY - dayEl.getBoundingClientRect().top + (scrollContainer ? scrollContainer.scrollTop : 0) - gridTop;
+      const y =
+        e.clientY -
+        dayEl.getBoundingClientRect().top +
+        (scrollContainer ? scrollContainer.scrollTop : 0) -
+        gridTop;
 
       // Calculate time from click position within the 1440px time grid
       const clampedY = Math.max(0, Math.min(y + gridTop, this.totalHeight));


### PR DESCRIPTION
## Summary
- Ran `npx prettier --write` on three renderer files that were failing the CI code quality check
- Fixes: `BaseViewRenderer.js`, `DayViewRenderer.js`, `WeekViewRenderer.js`
- Restores the Code Quality badge to passing on master

## Test plan
- [ ] Verify CI Code Quality workflow passes after merge