### PR TITLE
Fix debounce: remove no-op clearTimeout and preserve caller context

### DIFF
--- a/src/utils/DOMUtils.js
+++ b/src/utils/DOMUtils.js
@@ -171,12 +171,8 @@ export class DOMUtils {
   static debounce(func, wait = 250) {
     let timeout;
     return function executedFunction(...args) {
-      const later = () => {
-        clearTimeout(timeout);
-        func(...args);
-      };
       clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      timeout = setTimeout(() => func.apply(this, args), wait);
     };
   }
 


### PR DESCRIPTION
## Summary
- Removed the useless `clearTimeout(timeout)` inside the `later()` callback — the timeout has already fired when that line runs, making it a no-op
- Preserved caller's `this` context via `func.apply(this, args)` instead of losing it through direct `func(...args)` call
- Simplified to the canonical debounce pattern (clear → set → apply)

## Test plan
- [ ] Verify debounced functions still fire after the specified wait period
- [ ] Verify rapid calls correctly debounce (only the last call fires)
- [ ] Verify `this` context is preserved when debounced method is called on an object