### PR TITLE
Remove redundant bare import of ForceCalendar module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,5 +22,4 @@ export { WeekViewRenderer } from './renderers/WeekViewRenderer.js';
 export { DayViewRenderer } from './renderers/DayViewRenderer.js';
 
 // Components
-import './components/ForceCalendar.js';
 export { ForceCalendar } from './components/ForceCalendar.js';


### PR DESCRIPTION
## Summary
- Removed the bare side-effect `import './components/ForceCalendar.js'` on line 25 of `src/index.js`
- The `export { ForceCalendar } from './components/ForceCalendar.js'` on the next line already triggers module evaluation, including the `EventForm.js` custom element registration side effect
- Eliminates a confusing duplicate import that could mislead developers into thinking a bare import is required

## Test plan
- [ ] Verify `ForceCalendar` export is still available from the package entry point
- [ ] Verify `<forcecal-event-form>` custom element still registers correctly (side effect from EventForm.js)
- [ ] Run existing test suite to confirm no regressions