### PR TITLE
fix: escape all dynamic data in innerHTML templates to prevent XSS

### DIFF
--- a/src/components/ForceCalendar.js
+++ b/src/components/ForceCalendar.js
@@ -676,7 +676,7 @@ export class ForceCalendar extends BaseComponent {
                         <button class="fc-nav-arrow" data-action="previous" title="Previous">
                             ${this.getIcon('chevron-left')}
                         </button>
-                        <h2 class="fc-title">${title}</h2>
+                        <h2 class="fc-title">${DOMUtils.escapeHTML(title)}</h2>
                         <button class="fc-nav-arrow" data-action="next" title="Next">
                             ${this.getIcon('chevron-right')}
                         </button>

--- a/src/renderers/DayViewRenderer.js
+++ b/src/renderers/DayViewRenderer.js
@@ -101,10 +101,10 @@ export class DayViewRenderer extends BaseViewRenderer {
                 <div style="border-right: 1px solid var(--fc-border-color);"></div>
                 <div style="padding: 16px 24px;">
                     <div style="font-size: 12px; font-weight: 700; color: var(--fc-text-light); text-transform: uppercase; letter-spacing: 0.1em;">
-                        ${dayName}
+                        ${this.escapeHTML(dayName)}
                     </div>
                     <div style="font-size: 24px; font-weight: 600; margin-top: 4px; ${isToday ? 'color: var(--fc-danger-color);' : 'color: var(--fc-text-color);'}">
-                        ${dayDate.getDate()}
+                        ${this.escapeHTML(String(dayDate.getDate()))}
                     </div>
                 </div>
             </div>

--- a/src/renderers/MonthViewRenderer.js
+++ b/src/renderers/MonthViewRenderer.js
@@ -37,7 +37,7 @@ export class MonthViewRenderer extends BaseViewRenderer {
     let html = `
             <div class="fc-month-view" style="display: flex; flex-direction: column; height: 100%; min-height: 400px; background: var(--fc-background); border: 1px solid var(--fc-border-color);">
                 <div class="fc-month-header" style="display: grid; grid-template-columns: repeat(7, 1fr); border-bottom: 1px solid var(--fc-border-color); background: var(--fc-background-alt);">
-                    ${dayNames.map(d => `<div class="fc-month-header-cell" style="padding: 12px 8px; text-align: center; font-size: 11px; font-weight: 600; color: var(--fc-text-light); text-transform: uppercase;">${d}</div>`).join('')}
+                    ${dayNames.map(d => `<div class="fc-month-header-cell" style="padding: 12px 8px; text-align: center; font-size: 11px; font-weight: 600; color: var(--fc-text-light); text-transform: uppercase;">${this.escapeHTML(d)}</div>`).join('')}
                 </div>
                 <div class="fc-month-body" style="display: flex; flex-direction: column; flex: 1;">
         `;
@@ -87,10 +87,10 @@ export class MonthViewRenderer extends BaseViewRenderer {
     const moreCount = events.length - this.maxEventsToShow;
 
     return `
-            <div class="fc-month-day" data-date="${day.date}"
+            <div class="fc-month-day" data-date="${this.escapeHTML(day.date)}"
                  style="background: ${dayBg}; border-right: 1px solid var(--fc-border-color); border-bottom: 1px solid var(--fc-border-color); padding: 4px; min-height: 80px; cursor: pointer; display: flex; flex-direction: column;">
                 <div class="fc-day-number" style="font-size: 13px; font-weight: 500; color: ${dayNumColor}; padding: 2px 4px; margin-bottom: 4px; ${todayStyle}">
-                    ${day.dayOfMonth}
+                    ${this.escapeHTML(String(day.dayOfMonth))}
                 </div>
                 <div class="fc-day-events" style="display: flex; flex-direction: column; gap: 2px; flex: 1; overflow: hidden;">
                     ${visibleEvents.map(evt => this._renderEvent(evt)).join('')}

--- a/src/renderers/WeekViewRenderer.js
+++ b/src/renderers/WeekViewRenderer.js
@@ -71,10 +71,10 @@ export class WeekViewRenderer extends BaseViewRenderer {
                     day => `
                     <div style="padding: 12px 8px; text-align: center; border-right: 1px solid var(--fc-border-color);">
                         <div style="font-size: 10px; font-weight: 700; color: var(--fc-text-light); text-transform: uppercase; letter-spacing: 0.1em;">
-                            ${day.dayName}
+                            ${this.escapeHTML(day.dayName)}
                         </div>
                         <div style="font-size: 16px; font-weight: 500; margin-top: 4px; ${day.isToday ? 'background: var(--fc-danger-color); color: white; border-radius: 50%; width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;' : 'color: var(--fc-text-color);'}">
-                            ${day.dayOfMonth}
+                            ${this.escapeHTML(String(day.dayOfMonth))}
                         </div>
                     </div>
                 `


### PR DESCRIPTION
## Summary
- Escape day names, day numbers, date attributes, and calendar title text that were previously interpolated into HTML strings without sanitization
- MonthViewRenderer: escape `day.date` (data attribute) and `day.dayOfMonth`, day header names
- WeekViewRenderer: escape `day.dayName` and `day.dayOfMonth` in header
- DayViewRenderer: escape `dayName` and `dayDate.getDate()` in header
- ForceCalendar: escape title text via `DOMUtils.escapeHTML()`
- Event titles and IDs were already escaped -- this closes the remaining gaps

Closes #39

## Test plan
- [ ] Verify calendar renders correctly in month/week/day views
- [ ] Add an event with HTML in the title (e.g. `<img onerror=alert(1)>`) and confirm it renders as text
- [ ] Verify day names and numbers display correctly across locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)