### PR TITLE
Bump core to v2.1.21 with security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
-        "@forcecalendar/core": "^2.1.18",
+        "@forcecalendar/core": "^2.1.21",
         "babel-jest": "^30.2.0",
         "eslint": "^8.57.1",
         "jest": "^30.2.0",
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/@forcecalendar/core": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.18.tgz",
-      "integrity": "sha512-/o1h5mhSFMN/wLyVO5wfF4hCzJcs2d2BCG0fOYG8rxvOZSBfDXQTLEIWLoCNKe2pFF0WlM6pxYVNDiqlBaWpcw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.21.tgz",
+      "integrity": "sha512-Irmt/Q00Cb8nBfaMuW0by2jzVbsrVJDw7KnwaGbJGNHdA0w8G1xD+x3QqGNiS5+jmnfIlz1Hj/9WEE7MV3t9Bg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@forcecalendar/core": ">=2.0.0"
   },
   "devDependencies": {
-    "@forcecalendar/core": "^2.1.18",
+    "@forcecalendar/core": "^2.1.21",
     "@babel/core": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
     "babel-jest": "^30.2.0",


### PR DESCRIPTION
Updates `@forcecalendar/core` devDependency from `^2.1.18` to `^2.1.21`.

Core v2.1.21 includes all 7 security fixes:
- SSRF protection for ICS feed URLs
- ICS parser input size limits
- Prototype pollution guard in deep merge
- ReDoS-safe regex patterns
- And more

Build and all 13 tests pass.