### PR TITLE
fix: use contrasting text color for month view events

### DIFF
--- a/src/renderers/MonthViewRenderer.js
+++ b/src/renderers/MonthViewRenderer.js
@@ -102,9 +102,10 @@ export class MonthViewRenderer extends BaseViewRenderer {
 
   _renderEvent(event) {
     const color = this.getEventColor(event);
+    const textColor = this.getContrastingTextColor(color);
     return `
             <div class="fc-event" data-event-id="${this.escapeHTML(event.id)}"
-                 style="background-color: ${color}; font-size: 11px; padding: 2px 6px; border-radius: 3px; color: white; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer;">
+                 style="background-color: ${color}; font-size: 11px; padding: 2px 6px; border-radius: 3px; color: ${textColor}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: pointer;">
                 ${this.escapeHTML(event.title)}
             </div>
         `;


### PR DESCRIPTION
## Summary
- Month view events hardcoded `color: white`, which is unreadable on light event colors (yellow, light green, etc.) and fails WCAG contrast — while week/day views already computed a contrasting color.
- `_renderEvent()` now uses `getContrastingTextColor(color)` (YIQ luminance via `StyleUtils.getContrastColor`), matching `BaseViewRenderer.renderTimedEvent()` behavior. Non-hex colors keep the white fallback.

## Test plan
- Jest: 3 suites / 13 tests passing; eslint + prettier clean.

Fixes #68