### PR TITLE
fix: bump @forcecalendar/core to ^2.1.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
-        "@forcecalendar/core": "^2.1.21",
+        "@forcecalendar/core": "^2.1.54",
         "babel-jest": "^30.2.0",
         "eslint": "^8.57.1",
         "jest": "^30.2.0",
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/@forcecalendar/core": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.21.tgz",
-      "integrity": "sha512-Irmt/Q00Cb8nBfaMuW0by2jzVbsrVJDw7KnwaGbJGNHdA0w8G1xD+x3QqGNiS5+jmnfIlz1Hj/9WEE7MV3t9Bg==",
+      "version": "2.1.54",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.54.tgz",
+      "integrity": "sha512-ilVLpuS3u9hb0qemKhvgE9jtBTMPe7Q1+Ug9lte2BG/yAjD5brbd5M3UZc2mol/OHEO1FDXk38YHtDrqkxSv4Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "@forcecalendar/core": ">=2.0.0"
   },
   "devDependencies": {
-    "@forcecalendar/core": "^2.1.21",
     "@babel/core": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
+    "@forcecalendar/core": "^2.1.54",
     "babel-jest": "^30.2.0",
     "eslint": "^8.57.1",
     "jest": "^30.2.0",


### PR DESCRIPTION
## Summary
- Bumps `@forcecalendar/core` ^2.1.21 → ^2.1.54, consuming the freshly published core release (business-hours conflict fix, forceCalendar/core#153) so interface ships against what's actually on npm.

## Test plan
- Jest: 4 suites / 19 tests passing against core 2.1.54.
- Merging this triggers the auto-publish of interface v1.0.58 with both of today's fixes (#76 contrast, #77 EventBus) plus this dep bump.